### PR TITLE
Add 'add_rnbo' primitive.

### DIFF
--- a/py2max/core.py
+++ b/py2max/core.py
@@ -452,6 +452,8 @@ class Patcher:
             return self.add_subpatcher(value, **kwds)
         elif maxclass == 'gen~':
             return self.add_gen(value, **kwds)
+        elif maxclass == 'rnbo~':
+            return self.add_rnbo(value, **kwds)
         else:
             return self.add_textbox(text=value, **kwds)
 
@@ -632,6 +634,13 @@ class Patcher:
         return self.add_subpatcher(text,
                                    patcher=Patcher(parent=self,
                                                    classnamespace='gen.dsp'), **kwds)
+
+    def add_rnbo(self, text: str = 'rnbo~',  **kwds):
+        """Add a rnbo~ object."""
+
+        return self.add_subpatcher(text,
+                                   patcher=Patcher(parent=self,
+                                                   classnamespace='rnbo.dsp'), **kwds)
 
     def add_coll(self, name: str = None, dictionary: dict = None, embed: int = 1,
                  patching_rect: list[float] = None, text: str = None, id: str = None,


### PR DESCRIPTION
With this primitive, I can do:

```
from py2max import *

p = Patcher('outputs/test_rnbo.maxpat')
sbox = p.add_rnbo()
sp = sbox.subpatcher

in1 = sp.add_textbox('in~ 1')
in2 = sp.add_textbox('in~ 2')

out1 = sp.add_textbox('out~ 1')
out2 = sp.add_textbox('out~ 2')

sp.add_line(in1, out1)
sp.add_line(in2, out2)
p.save()
```

Then I would like to add a `codebox~` inside it, but if I do:

`cb = sp.add_textbox('codebox')`

the resulting patch makes Max/MSP crash when loading it.

Any idea ? Or any other  idea on how to add `codebox~` inside a `rnbo~ ` one?

